### PR TITLE
Fix precomputeInstances to allow false

### DIFF
--- a/DynamicTerrain/src/babylon.dynamicTerrain.ts
+++ b/DynamicTerrain/src/babylon.dynamicTerrain.ts
@@ -167,7 +167,7 @@ module BABYLON {
             this._instanceMapData = options.instanceMapData;
             this._instanceColorData = options.instanceColorData;
             this._sourceMeshes = options.sourceMeshes;
-            this._precomputeInstances = (options.precomputeInstances) ? (options.precomputeInstances) : true;
+            this._precomputeInstances = (typeof options.precomputeInstances === undefined) ? true : options.precomputeInstances;
             
             // initialize the map arrays if not passed as parameters
             this._datamap = (this._mapData) ? true : false;


### PR DESCRIPTION
In its current implementation, the precomputeInstances option is always set to true, regardless of what is passed as the value when creating the terrain. I updated the assignment of this._precomputeInstances to check for undefined instead of checking for a true/false value.