### PR TITLE
Add four fit strategies for the HtmlElement how to fit the HtmlMesh size

### DIFF
--- a/HtmlMesh/README-npm.md
+++ b/HtmlMesh/README-npm.md
@@ -52,8 +52,13 @@ HtmlMesh using the `capturePointerEvents` and `releasePointerEvents` methods.
     * require that the scene clear color is transparent
     * must be opaque 
     * must be rectangular
-
-    In contrast, overlay meshes:
+* `fitStrategy` - Specifies the HtmlElement how to fit the HtmlMesh's size. Fit behavior is like css background-size
+    * FitStrategy.NONE Default. Display HtmlElement at its original size in HtmlMesh without any scaling
+    * FitStrategy.CONTAIN Scales the HtmlElement as large as possible within its container without cropping or stretching, HtmlElement should define an appropriate width
+    * FitStrategy.COVER Scales the HtmlElement (while preserving its ratio) to the smallest possible size to fill the HtmlMesh (that is: both its height and width completely cover the HtmlMesh), leaving no empty space. If the proportions of the HtmlElement differ from the HtmlMesh, the HtmlElement is cropped either vertically or horizontally.
+    * FitStrategy.STRETCH Stretches the HtmlElement in the corresponding dimension to the 100% length
+    
+  In contrast, overlay meshes:
     * always render in front of other scene content
     * can be semi-transparent 
     * can be non-rectangular
@@ -169,7 +174,7 @@ const createScene = () => {
     htmlMeshVideo.position.x = 3;
     htmlMeshVideo.position.y = -2;
 
-    // Shows how to create an HTML Overlay
+    // Shows how to create an HTML Overlay by the fit strategy: FitStrategy.NONE
     const overlayMesh = new HtmlMesh(scene, "html-overlay-mesh", { isCanvasOverlay: true });
     const overlayMeshDiv = document.createElement('div');
     overlayMeshDiv.innerHTML = `<p>This is an overlay. It is positioned in front of the canvas This allows it to have transparency and to be non-rectangular, but it will always show over any other content in the scene</p>`;
@@ -187,6 +192,55 @@ const createScene = () => {
     overlayMesh.setContent(overlayMeshDiv, 4, 3);
     overlayMesh.position.x = 0;
     overlayMesh.position.y = 0;
+
+    // Shows how to create an HTML Overlay by the fit strategy: FitStrategy.CONTAIN
+    const overlayContainMesh = new HtmlMesh(scene, "html-overlay-mesh-contain",{ isCanvasOverlay: true, fitStrategy: FitStrategy.CONTAIN });
+    const overlayContainMeshDiv = document.createElement('div');
+    overlayContainMeshDiv.innerHTML = `Contain: This is an overlay. It is positioned in front of the canvas This allows it to have transparency and to be non-rectangular, but it will always show over any other content in the scene`;
+    overlayContainMeshDiv.style.width = '200px';
+    overlayContainMeshDiv.style.display = 'flex';
+    overlayContainMeshDiv.style.alignItems = 'center';
+    overlayContainMeshDiv.style.justifyContent = 'center';
+    overlayContainMeshDiv.style.padding = '10px';
+    overlayContainMeshDiv.style.backgroundColor = 'rgba(25,0,255,0.49)';
+  
+    overlayContainMesh.setContent(overlayContainMeshDiv, 4, 3);
+    overlayContainMesh.position.x = 0;
+    overlayContainMesh.position.y = 3.5;
+    overlayContainMesh.billboardMode = 7;
+  
+    // Shows how to create an HTML Overlay by the fit strategy: FitStrategy.COVER
+    const overlayCoverMesh = new HtmlMesh(scene, "html-overlay-mesh-cover", { isCanvasOverlay: true, fitStrategy: FitStrategy.COVER });
+    const overlayCoverMeshDiv = document.createElement('div');
+    overlayCoverMeshDiv.innerHTML = `Cover: This is an overlay. It is positioned in front of the canvas This allows it to have transparency and to be non-rectangular, but it will always show over any other content in the scene`;
+    overlayCoverMeshDiv.style.backgroundColor = 'rgba(25,0,255,0.49)';
+    overlayCoverMeshDiv.style.width = '150px';
+    overlayCoverMeshDiv.style.display = 'flex';
+    overlayCoverMeshDiv.style.alignItems = 'center';
+    overlayCoverMeshDiv.style.justifyContent = 'center';
+    overlayCoverMeshDiv.style.padding = '10px';
+    overlayCoverMeshDiv.style.overflow = 'hidden';
+  
+    overlayCoverMesh.setContent(overlayCoverMeshDiv, 4, 3);
+    overlayCoverMesh.position.x = -2.5;
+    overlayCoverMesh.position.y = 7;
+    overlayCoverMesh.billboardMode = 7;
+
+    // Shows how to create an HTML Overlay by the fit strategy: FitStrategy.STRETCH
+    const overlayStretchMesh = new HtmlMesh(scene, "html-overlay-mesh-stretch", { isCanvasOverlay: true, fitStrategy: FitStrategy.STRETCH });
+    const overlayStretchMeshDiv = document.createElement('div');
+    overlayStretchMeshDiv.innerHTML = `Stretch: This is an overlay. It is positioned in front of the canvas This allows it to have transparency and to be non-rectangular, but it will always show over any other content in the scene`;
+    overlayStretchMeshDiv.style.backgroundColor = 'rgba(25,0,255,0.49)';
+    overlayStretchMeshDiv.style.width = '400px';
+    overlayStretchMeshDiv.style.display = 'flex';
+    overlayStretchMeshDiv.style.alignItems = 'center';
+    overlayStretchMeshDiv.style.justifyContent = 'center';
+    overlayStretchMeshDiv.style.padding = '10px';
+  
+    overlayStretchMesh.setContent(overlayStretchMeshDiv, 4, 3);
+    overlayStretchMesh.position.x = 2;
+    overlayStretchMesh.position.y = 7;
+    overlayStretchMesh.billboardMode = 7;
 };
 
 const startRenderLoop = () => {

--- a/HtmlMesh/README.md
+++ b/HtmlMesh/README.md
@@ -52,6 +52,11 @@ HtmlMesh using the `capturePointerEvents` and `releasePointerEvents` methods.
     * require that the scene clear color is transparent
     * must be opaque 
     * must be rectangular
+* `fitStrategy` - Specifies the HtmlElement how to fit the HtmlMesh's size. Fit behavior is like css background-size
+    * FitStrategy.NONE Default. Display HtmlElement at its original size in HtmlMesh without any scaling
+    * FitStrategy.CONTAIN Scales the HtmlElement as large as possible within its container without cropping or stretching, HtmlElement should define an appropriate width
+    * FitStrategy.COVER Scales the HtmlElement (while preserving its ratio) to the smallest possible size to fill the HtmlMesh (that is: both its height and width completely cover the HtmlMesh), leaving no empty space. If the proportions of the HtmlElement differ from the HtmlMesh, the HtmlElement is cropped either vertically or horizontally.
+    * FitStrategy.STRETCH Stretches the HtmlElement in the corresponding dimension to the 100% length
 
     In contrast, overlay meshes:
     * always render in front of other scene content
@@ -169,7 +174,7 @@ const createScene = () => {
     htmlMeshVideo.position.x = 3;
     htmlMeshVideo.position.y = -2;
 
-    // Shows how to create an HTML Overlay
+    // Shows how to create an HTML Overlay by the fit strategy: FitStrategy.NONE
     const overlayMesh = new HtmlMesh(scene, "html-overlay-mesh", { isCanvasOverlay: true });
     const overlayMeshDiv = document.createElement('div');
     overlayMeshDiv.innerHTML = `<p>This is an overlay. It is positioned in front of the canvas This allows it to have transparency and to be non-rectangular, but it will always show over any other content in the scene</p>`;
@@ -187,6 +192,56 @@ const createScene = () => {
     overlayMesh.setContent(overlayMeshDiv, 4, 3);
     overlayMesh.position.x = 0;
     overlayMesh.position.y = 0;
+
+    // Shows how to create an HTML Overlay by the fit strategy: FitStrategy.CONTAIN
+    const overlayContainMesh = new HtmlMesh(scene, "html-overlay-mesh-contain",{ isCanvasOverlay: true, fitStrategy: FitStrategy.CONTAIN });
+    const overlayContainMeshDiv = document.createElement('div');
+    overlayContainMeshDiv.innerHTML = `Contain: This is an overlay. It is positioned in front of the canvas This allows it to have transparency and to be non-rectangular, but it will always show over any other content in the scene`;
+    overlayContainMeshDiv.style.width = '200px';
+    overlayContainMeshDiv.style.display = 'flex';
+    overlayContainMeshDiv.style.alignItems = 'center';
+    overlayContainMeshDiv.style.justifyContent = 'center';
+    overlayContainMeshDiv.style.padding = '10px';
+    overlayContainMeshDiv.style.backgroundColor = 'rgba(25,0,255,0.49)';
+  
+    overlayContainMesh.setContent(overlayContainMeshDiv, 4, 3);
+    overlayContainMesh.position.x = 0;
+    overlayContainMesh.position.y = 3.5;
+    overlayContainMesh.billboardMode = 7;
+  
+    // Shows how to create an HTML Overlay by the fit strategy: FitStrategy.COVER
+    const overlayCoverMesh = new HtmlMesh(scene, "html-overlay-mesh-cover", { isCanvasOverlay: true, fitStrategy: FitStrategy.COVER });
+    const overlayCoverMeshDiv = document.createElement('div');
+    overlayCoverMeshDiv.innerHTML = `Cover: This is an overlay. It is positioned in front of the canvas This allows it to have transparency and to be non-rectangular, but it will always show over any other content in the scene`;
+    overlayCoverMeshDiv.style.backgroundColor = 'rgba(25,0,255,0.49)';
+    overlayCoverMeshDiv.style.width = '150px';
+    overlayCoverMeshDiv.style.display = 'flex';
+    overlayCoverMeshDiv.style.alignItems = 'center';
+    overlayCoverMeshDiv.style.justifyContent = 'center';
+    overlayCoverMeshDiv.style.padding = '10px';
+    overlayCoverMeshDiv.style.overflow = 'hidden';
+  
+    overlayCoverMesh.setContent(overlayCoverMeshDiv, 4, 3);
+    overlayCoverMesh.position.x = -2.5;
+    overlayCoverMesh.position.y = 7;
+    overlayCoverMesh.billboardMode = 7;
+  
+    // Shows how to create an HTML Overlay by the fit strategy: FitStrategy.STRETCH
+    const overlayStretchMesh = new HtmlMesh(scene, "html-overlay-mesh-stretch", { isCanvasOverlay: true, fitStrategy: FitStrategy.STRETCH });
+    const overlayStretchMeshDiv = document.createElement('div');
+    overlayStretchMeshDiv.innerHTML = `Stretch: This is an overlay. It is positioned in front of the canvas This allows it to have transparency and to be non-rectangular, but it will always show over any other content in the scene`;
+    overlayStretchMeshDiv.style.backgroundColor = 'rgba(25,0,255,0.49)';
+    overlayStretchMeshDiv.style.width = '400px';
+    overlayStretchMeshDiv.style.display = 'flex';
+    overlayStretchMeshDiv.style.alignItems = 'center';
+    overlayStretchMeshDiv.style.justifyContent = 'center';
+    overlayStretchMeshDiv.style.padding = '10px';
+  
+    overlayStretchMesh.setContent(overlayStretchMeshDiv, 4, 3);
+    overlayStretchMesh.position.x = 2;
+    overlayStretchMesh.position.y = 7;
+    overlayStretchMesh.billboardMode = 7;
+
 };
 
 const startRenderLoop = () => {

--- a/HtmlMesh/example.js
+++ b/HtmlMesh/example.js
@@ -8,7 +8,7 @@ import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import "@babylonjs/core/Helpers/sceneHelpers";
 
 import { HtmlMeshRenderer } from "./src/html-mesh-renderer";
-import { HtmlMesh } from "./src/html-mesh";
+import {HtmlMesh, SizeFit} from "./src/html-mesh";
 
 import { ArcRotateCamera } from "@babylonjs/core/Cameras/arcRotateCamera";
 import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
@@ -27,7 +27,7 @@ const createScene = () => {
     scene.clearColor = new Color4(0,0,0,0);
 
     scene.createDefaultCameraOrLight(true, true, true);
-    scene.activeCamera.radius = 20;
+    scene.activeCamera.radius = 23;
 
     // Uncomment these lines to test issue #261
     // const camera = new ArcRotateCamera('', -Math.PI / 3, Math.PI / 2.5, 20, Vector3.Zero(), scene)
@@ -44,8 +44,8 @@ const createScene = () => {
     // over the html mesh, or if it is masked.
     var disc = MeshBuilder.CreateDisc("disc", {radius: 0.5});
 
-    bg.scaling.x = 12;
-    bg.scaling.y = 16;
+    bg.scaling.x = 16;
+    bg.scaling.y = 20;
     bg.position.z = 3;
 
     sphere.position.x = 1.5;
@@ -106,7 +106,7 @@ const createScene = () => {
     `;
     div.style.backgroundColor = "white";
     div.style.width = "480px";
-    div.style.height = "360px";    
+    div.style.height = "360px";
 
     htmlMeshDiv.setContent(div, 4, 3);
     htmlMeshDiv.position.x = -3;
@@ -186,6 +186,55 @@ const createScene = () => {
     overlayMesh.position.y = 0;
     // Uncomment this line to test issue #268 (Delayed creation issue)
     //}, 3000);
+
+    // overlayMesh fit contain
+    const overlayContainMesh = new HtmlMesh(scene, "html-overlay-mesh-contain", { isCanvasOverlay: true, sizeFit: SizeFit.contain });
+    const overlayContainMeshDiv = document.createElement('div');
+    overlayContainMeshDiv.innerHTML = `Contain: This is an overlay. It is positioned in front of the canvas This allows it to have transparency and to be non-rectangular, but it will always show over any other content in the scene`;
+    overlayContainMeshDiv.style.backgroundColor = 'rgba(25,0,255,0.49)';
+    overlayContainMeshDiv.style.width = '200px';
+    overlayContainMeshDiv.style.display = 'flex';
+    overlayContainMeshDiv.style.alignItems = 'center';
+    overlayContainMeshDiv.style.justifyContent = 'center';
+    overlayContainMeshDiv.style.padding = '10px';
+
+    overlayContainMesh.setContent(overlayContainMeshDiv, 4, 3);
+    overlayContainMesh.position.x = 0;
+    overlayContainMesh.position.y = 3.5;
+    overlayContainMesh.billboardMode = 7;
+
+    // overlayMesh fit cover
+    const overlayCoverMesh = new HtmlMesh(scene, "html-overlay-mesh-cover", { isCanvasOverlay: true, sizeFit: SizeFit.cover });
+    const overlayCoverMeshDiv = document.createElement('div');
+    overlayCoverMeshDiv.innerHTML = `Cover: This is an overlay. It is positioned in front of the canvas This allows it to have transparency and to be non-rectangular, but it will always show over any other content in the scene`;
+    overlayCoverMeshDiv.style.backgroundColor = 'rgba(25,0,255,0.49)';
+    overlayCoverMeshDiv.style.width = '150px';
+    overlayCoverMeshDiv.style.display = 'flex';
+    overlayCoverMeshDiv.style.alignItems = 'center';
+    overlayCoverMeshDiv.style.justifyContent = 'center';
+    overlayCoverMeshDiv.style.padding = '10px';
+    overlayCoverMeshDiv.style.overflow = 'hidden';
+
+    overlayCoverMesh.setContent(overlayCoverMeshDiv, 4, 3);
+    overlayCoverMesh.position.x = -2.5;
+    overlayCoverMesh.position.y = 7;
+    overlayCoverMesh.billboardMode = 7;
+
+    // overlayMesh fit stretch
+    const overlayStretchMesh = new HtmlMesh(scene, "html-overlay-mesh-stretch", { isCanvasOverlay: true, sizeFit: SizeFit.stretch });
+    const overlayStretchMeshDiv = document.createElement('div');
+    overlayStretchMeshDiv.innerHTML = `Stretch: This is an overlay. It is positioned in front of the canvas This allows it to have transparency and to be non-rectangular, but it will always show over any other content in the scene`;
+    overlayStretchMeshDiv.style.backgroundColor = 'rgba(25,0,255,0.49)';
+    overlayStretchMeshDiv.style.width = '400px';
+    overlayStretchMeshDiv.style.display = 'flex';
+    overlayStretchMeshDiv.style.alignItems = 'center';
+    overlayStretchMeshDiv.style.justifyContent = 'center';
+    overlayStretchMeshDiv.style.padding = '10px';
+
+    overlayStretchMesh.setContent(overlayStretchMeshDiv, 4, 3);
+    overlayStretchMesh.position.x = 2;
+    overlayStretchMesh.position.y = 7;
+    overlayStretchMesh.billboardMode = 7;
 
     // Uncomment this line to test issue #264
     //MeshBuilder.CreateBox("box2", {size: 1}, scene);

--- a/HtmlMesh/example.js
+++ b/HtmlMesh/example.js
@@ -8,10 +8,11 @@ import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import "@babylonjs/core/Helpers/sceneHelpers";
 
 import { HtmlMeshRenderer } from "./src/html-mesh-renderer";
-import {HtmlMesh, SizeFit} from "./src/html-mesh";
+import { HtmlMesh } from "./src/html-mesh";
 
 import { ArcRotateCamera } from "@babylonjs/core/Cameras/arcRotateCamera";
 import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
+import { FitStrategy } from "./src/fit-strategy";
 
 const debug = true;
 
@@ -188,15 +189,15 @@ const createScene = () => {
     //}, 3000);
 
     // overlayMesh fit contain
-    const overlayContainMesh = new HtmlMesh(scene, "html-overlay-mesh-contain", { isCanvasOverlay: true, sizeFit: SizeFit.contain });
+    const overlayContainMesh = new HtmlMesh(scene, "html-overlay-mesh-contain",{ isCanvasOverlay: true, fitStrategy: FitStrategy.CONTAIN });
     const overlayContainMeshDiv = document.createElement('div');
     overlayContainMeshDiv.innerHTML = `Contain: This is an overlay. It is positioned in front of the canvas This allows it to have transparency and to be non-rectangular, but it will always show over any other content in the scene`;
-    overlayContainMeshDiv.style.backgroundColor = 'rgba(25,0,255,0.49)';
     overlayContainMeshDiv.style.width = '200px';
     overlayContainMeshDiv.style.display = 'flex';
     overlayContainMeshDiv.style.alignItems = 'center';
     overlayContainMeshDiv.style.justifyContent = 'center';
     overlayContainMeshDiv.style.padding = '10px';
+    overlayContainMeshDiv.style.backgroundColor = 'rgba(25,0,255,0.49)';
 
     overlayContainMesh.setContent(overlayContainMeshDiv, 4, 3);
     overlayContainMesh.position.x = 0;
@@ -204,7 +205,7 @@ const createScene = () => {
     overlayContainMesh.billboardMode = 7;
 
     // overlayMesh fit cover
-    const overlayCoverMesh = new HtmlMesh(scene, "html-overlay-mesh-cover", { isCanvasOverlay: true, sizeFit: SizeFit.cover });
+    const overlayCoverMesh = new HtmlMesh(scene, "html-overlay-mesh-cover", { isCanvasOverlay: true, fitStrategy: FitStrategy.COVER });
     const overlayCoverMeshDiv = document.createElement('div');
     overlayCoverMeshDiv.innerHTML = `Cover: This is an overlay. It is positioned in front of the canvas This allows it to have transparency and to be non-rectangular, but it will always show over any other content in the scene`;
     overlayCoverMeshDiv.style.backgroundColor = 'rgba(25,0,255,0.49)';
@@ -220,8 +221,10 @@ const createScene = () => {
     overlayCoverMesh.position.y = 7;
     overlayCoverMesh.billboardMode = 7;
 
+    // https://github.com/BabylonJS/Extensions/pull/270
+
     // overlayMesh fit stretch
-    const overlayStretchMesh = new HtmlMesh(scene, "html-overlay-mesh-stretch", { isCanvasOverlay: true, sizeFit: SizeFit.stretch });
+    const overlayStretchMesh = new HtmlMesh(scene, "html-overlay-mesh-stretch", { isCanvasOverlay: true, fitStrategy: FitStrategy.STRETCH });
     const overlayStretchMeshDiv = document.createElement('div');
     overlayStretchMeshDiv.innerHTML = `Stretch: This is an overlay. It is positioned in front of the canvas This allows it to have transparency and to be non-rectangular, but it will always show over any other content in the scene`;
     overlayStretchMeshDiv.style.backgroundColor = 'rgba(25,0,255,0.49)';

--- a/HtmlMesh/src/fit-strategy.ts
+++ b/HtmlMesh/src/fit-strategy.ts
@@ -1,0 +1,96 @@
+export type FitStrategyType = {
+  wrapElement(element: HTMLElement): HTMLElement
+  updateSize(sizingElement: HTMLElement, width: number, height: number): void
+}
+
+const FitStrategyContain: FitStrategyType = {
+  wrapElement(element: HTMLElement): HTMLElement {
+    const sizingElement = document.createElement('div')
+    sizingElement.style.display = 'flex'
+    sizingElement.style.justifyContent = 'center'
+    sizingElement.style.alignItems = 'center'
+    const scalingElement = document.createElement('div')
+    scalingElement.style.visibility = 'hidden'
+    scalingElement.appendChild(element)
+    sizingElement.appendChild(scalingElement)
+    return sizingElement
+  },
+  updateSize(sizingElement: HTMLElement, width: number, height: number) {
+    const scalingElement = sizingElement.firstElementChild! as HTMLElement
+    sizingElement.style.width = `${width}px`
+    sizingElement.style.height = `${height}px`
+
+    const [childWidth, childHeight] = [scalingElement!.offsetWidth, scalingElement!.offsetHeight]
+    const scale = Math.min(width / childWidth, height / childHeight)
+    scalingElement.style.transform = `scale(${scale})`
+    scalingElement.style.visibility = 'visible'
+  }
+}
+
+const FitStrategyCover: FitStrategyType = {
+  wrapElement(element: HTMLElement): HTMLElement {
+    const sizingElement = document.createElement('div')
+    sizingElement.style.display = 'flex'
+    sizingElement.style.justifyContent = 'center'
+    sizingElement.style.alignItems = 'center'
+    sizingElement.style.overflow = 'hidden'
+    const scalingElement = document.createElement('div')
+    scalingElement.style.visibility = 'hidden'
+    scalingElement.appendChild(element)
+    sizingElement.appendChild(scalingElement)
+    return sizingElement
+  },
+  updateSize(sizingElement: HTMLElement, width: number, height: number) {
+    const scalingElement = sizingElement.firstElementChild! as HTMLElement
+    sizingElement.style.width = `${width}px`
+    sizingElement.style.height = `${height}px`
+
+    const [childWidth, childHeight] = [scalingElement!.offsetWidth, scalingElement!.offsetHeight]
+    const scale = Math.max(width / childWidth, height / childHeight)
+    scalingElement.style.transform = `scale(${scale})`
+    scalingElement.style.visibility = 'visible'
+  }
+}
+
+
+const FitStrategyStretch: FitStrategyType = {
+  wrapElement(element: HTMLElement): HTMLElement {
+    const sizingElement = document.createElement('div')
+    sizingElement.style.display = 'flex'
+    sizingElement.style.justifyContent = 'center'
+    sizingElement.style.alignItems = 'center'
+    const scalingElement = document.createElement('div')
+    scalingElement.style.visibility = 'hidden'
+    scalingElement.appendChild(element)
+    sizingElement.appendChild(scalingElement)
+    return sizingElement
+  },
+  updateSize(sizingElement: HTMLElement, width: number, height: number) {
+    const scalingElement = sizingElement.firstElementChild! as HTMLElement
+    sizingElement.style.width = `${width}px`
+    sizingElement.style.height = `${height}px`
+
+    const [childWidth, childHeight] = [scalingElement!.offsetWidth, scalingElement!.offsetHeight]
+    scalingElement.style.transform = `scale(${width / childWidth}, ${height / childHeight})`
+    scalingElement.style.visibility = 'visible'
+  }
+}
+
+const FitStrategyNone: FitStrategyType = {
+  wrapElement(element: HTMLElement): HTMLElement {
+    return element
+  },
+  updateSize(sizingElement: HTMLElement, width: number, height: number) {
+    if (sizingElement) {
+      sizingElement.style.width = `${width}px`;
+      sizingElement.style.height = `${height}px`;
+    }
+  }
+}
+
+export const FitStrategy = {
+  CONTAIN: FitStrategyContain,
+  COVER: FitStrategyCover,
+  STRETCH: FitStrategyStretch,
+  NONE: FitStrategyNone
+}


### PR DESCRIPTION
add fit strategy specifics to READMEs, move fit strategy implementions to 'fit-strategy.ts'. change SizeFit to FitStrategy.
Sorry, My English is not good. The description in readme may be incorrect, and need you to make some modifications