### PR TITLE
Exposure of FitStrategy interface and newly approached canvas size calculation for HtmlMesh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 .tempChromeProfileForDebug
-*.map 
+*.map
+
+.idea

--- a/HtmlMesh/index.js
+++ b/HtmlMesh/index.js
@@ -1,10 +1,12 @@
 import { HtmlMeshRenderer } from './src/html-mesh-renderer';
 import { HtmlMesh } from './src/html-mesh';
 import { PointerEventsCaptureBehavior } from './src/pointer-events-capture-behavior';
+import { FitStrategy } from './src/fit-strategy';
 
 // Export public classes and functions
 export {
   HtmlMeshRenderer,
   HtmlMesh,
-  PointerEventsCaptureBehavior
+  PointerEventsCaptureBehavior,
+  FitStrategy
 };

--- a/HtmlMesh/src/fit-strategy.ts
+++ b/HtmlMesh/src/fit-strategy.ts
@@ -88,9 +88,16 @@ const FitStrategyNone: FitStrategyType = {
   }
 }
 
-export const FitStrategy = {
-  CONTAIN: FitStrategyContain,
-  COVER: FitStrategyCover,
-  STRETCH: FitStrategyStretch,
-  NONE: FitStrategyNone
+export enum FitStrategy {
+    CONTAIN = 'CONTAIN',
+    COVER = 'COVER',
+    STRETCH = 'STRETCH',
+    NONE = 'NONE'
+}
+
+export const FitStrategyMap = {
+  [FitStrategy.CONTAIN]: FitStrategyContain,
+  [FitStrategy.COVER]: FitStrategyCover,
+  [FitStrategy.STRETCH]: FitStrategyStretch,
+  [FitStrategy.NONE]: FitStrategyNone
 }

--- a/HtmlMesh/src/fit-strategy.ts
+++ b/HtmlMesh/src/fit-strategy.ts
@@ -89,10 +89,10 @@ const FitStrategyNone: FitStrategyType = {
 }
 
 export enum FitStrategy {
-    CONTAIN = 'CONTAIN',
-    COVER = 'COVER',
-    STRETCH = 'STRETCH',
-    NONE = 'NONE'
+    CONTAIN = 3,
+    COVER = 2,
+    STRETCH = 1,
+    NONE = 0
 }
 
 export const FitStrategyMap = {

--- a/HtmlMesh/src/fit-strategy.ts
+++ b/HtmlMesh/src/fit-strategy.ts
@@ -88,16 +88,9 @@ const FitStrategyNone: FitStrategyType = {
   }
 }
 
-export enum FitStrategy {
-    CONTAIN = 3,
-    COVER = 2,
-    STRETCH = 1,
-    NONE = 0
-}
-
-export const FitStrategyMap = {
-  [FitStrategy.CONTAIN]: FitStrategyContain,
-  [FitStrategy.COVER]: FitStrategyCover,
-  [FitStrategy.STRETCH]: FitStrategyStretch,
-  [FitStrategy.NONE]: FitStrategyNone
+export const FitStrategy = {
+  CONTAIN: FitStrategyContain,
+  COVER: FitStrategyCover,
+  STRETCH: FitStrategyStretch,
+  NONE: FitStrategyNone
 }

--- a/HtmlMesh/src/html-mesh-renderer.ts
+++ b/HtmlMesh/src/html-mesh-renderer.ts
@@ -14,6 +14,8 @@ import { Logger, Observer } from "@babylonjs/core";
 const _positionUpdateFailMessage =
     "Failed to update html mesh renderer position due to failure to get canvas rect.  HtmlMesh instances may not render correctly";
 
+const _defaultRenderingSize = { width: 0, height: 0 };
+
 /**
  * A function that compares two submeshes and returns a number indicating which
  * should be rendered first.
@@ -214,18 +216,21 @@ export class HtmlMeshRenderer {
             );
         }
 
+        const { width, height } = scene.getEngine().getRenderingCanvasClientRect() ?? _defaultRenderingSize;
         // Set the size and resize behavior
         this.setSize(
-            scene.getEngine().getRenderWidth(),
-            scene.getEngine().getRenderHeight()
+            width,
+            height
         );
 
         const engine = scene.getEngine();
         const onResize = () => {
             engine.resize();
+
+            const { width, height } = scene.getEngine().getRenderingCanvasClientRect() ?? _defaultRenderingSize;
             this.setSize(
-                scene.getEngine().getRenderWidth(),
-                scene.getEngine().getRenderHeight()
+                width,
+                height
             );
         };
         const boundOnResize = onResize.bind(this);

--- a/HtmlMesh/src/html-mesh-renderer.ts
+++ b/HtmlMesh/src/html-mesh-renderer.ts
@@ -227,7 +227,7 @@ export class HtmlMeshRenderer {
         const onResize = () => {
             engine.resize();
 
-            const { width, height } = scene.getEngine().getRenderingCanvasClientRect() ?? _defaultRenderingSize;
+            const { width, height } = getCanvasRectOrNull(scene) ?? _defaultRenderingSize;
             this.setSize(
                 width,
                 height

--- a/HtmlMesh/src/html-mesh-renderer.ts
+++ b/HtmlMesh/src/html-mesh-renderer.ts
@@ -8,7 +8,7 @@ import { Camera } from "@babylonjs/core/Cameras/camera";
 import { SubMesh } from "@babylonjs/core/Meshes/subMesh";
 import { RenderingGroup } from "@babylonjs/core/Rendering/renderingGroup";
 
-import { babylonUnitsToPixels, getCanvasRectAsync } from "./util";
+import { babylonUnitsToPixels, getCanvasRectAsync, getCanvasRectOrNull } from "./util";
 import { Logger, Observer } from "@babylonjs/core";
 
 const _positionUpdateFailMessage =
@@ -216,7 +216,7 @@ export class HtmlMeshRenderer {
             );
         }
 
-        const { width, height } = scene.getEngine().getRenderingCanvasClientRect() ?? _defaultRenderingSize;
+        const { width, height } = getCanvasRectOrNull(scene) ?? _defaultRenderingSize;
         // Set the size and resize behavior
         this.setSize(
             width,

--- a/HtmlMesh/src/html-mesh.ts
+++ b/HtmlMesh/src/html-mesh.ts
@@ -5,7 +5,7 @@ import { Matrix } from "@babylonjs/core/Maths/math";
 import { PointerEventsCaptureBehavior } from "./pointer-events-capture-behavior";
 import { Scene } from "@babylonjs/core";
 import { Logger } from "@babylonjs/core/Misc/logger";
-import { FitStrategy, FitStrategyMap, FitStrategyType } from "./fit-strategy.ts";
+import { FitStrategy, FitStrategyType } from "./fit-strategy.ts";
 
 /**
  * This class represents HTML content that we want to render as though it is part of the scene.  The HTML content is actually
@@ -45,7 +45,7 @@ export class HtmlMesh extends Mesh {
 
     worldMatrixUpdateObserver: any;
 
-    _fitStrategy: FitStrategyType = FitStrategyMap[FitStrategy.NONE];
+    _fitStrategy: FitStrategyType = FitStrategy.NONE;
 
     /**
      * Contruct an instance of HtmlMesh
@@ -71,7 +71,7 @@ export class HtmlMesh extends Mesh {
             return;
         }
 
-        this._fitStrategy = FitStrategyMap[fitStrategy]
+        this._fitStrategy = fitStrategy;
         this._isCanvasOverlay = isCanvasOverlay;
         this.createMask();
         this._element = this.createElement();

--- a/HtmlMesh/src/html-mesh.ts
+++ b/HtmlMesh/src/html-mesh.ts
@@ -5,7 +5,7 @@ import { Matrix } from "@babylonjs/core/Maths/math";
 import { PointerEventsCaptureBehavior } from "./pointer-events-capture-behavior";
 import { Scene } from "@babylonjs/core";
 import { Logger } from "@babylonjs/core/Misc/logger";
-import { FitStrategy, FitStrategyType } from "./fit-strategy.ts";
+import { FitStrategy, FitStrategyMap, FitStrategyType } from "./fit-strategy.ts";
 
 /**
  * This class represents HTML content that we want to render as though it is part of the scene.  The HTML content is actually
@@ -45,7 +45,7 @@ export class HtmlMesh extends Mesh {
 
     worldMatrixUpdateObserver: any;
 
-    _fitStrategy: FitStrategyType = FitStrategy.NONE;
+    _fitStrategy: FitStrategyType = FitStrategyMap[FitStrategy.NONE];
 
     /**
      * Contruct an instance of HtmlMesh
@@ -71,7 +71,7 @@ export class HtmlMesh extends Mesh {
             return;
         }
 
-        this._fitStrategy = fitStrategy
+        this._fitStrategy = FitStrategyMap[fitStrategy]
         this._isCanvasOverlay = isCanvasOverlay;
         this.createMask();
         this._element = this.createElement();


### PR DESCRIPTION
Hello there,

I stumbled upon several obstacles while integrating the `HtmlMesh` into my project. As far as they can be considered to have a general character I decided to write this proposal which would be incredibly useful to me and many others. 

### Points tackled in this PR:

- **Inability of customising the `FitStrategy`**: Even though this API being mentioned numerous times throughout the doc, it was never exposed thus making it of no leverage.
- **Miscalculated canvas size on different hardware**: I've discovered that on some monitors the css container size and translations are being miscalculated and as I found out later it happens due to the fact that `HtmlMeshRenderer`'s using the canvas render size which natively gets scaled respectively to the `hardwareScalingLevel`. I believe it would be appropriate to replace the usage essentially with the client size of the canvas itself.

If you see any possible caveats with this proposal please let me know and I'll align on these points.