### PR TITLE
Fixed the issue where the new pop-up box cannot capture mouse events after switching scenes.

### DIFF
--- a/HtmlMesh/src/pointer-events-capture-behavior.ts
+++ b/HtmlMesh/src/pointer-events-capture-behavior.ts
@@ -183,7 +183,7 @@ export class PointerEventsCaptureBehavior implements Behavior<AbstractMesh> {
         }
         // Remove the reference to this behavior from the mesh
         meshToBehaviorMap.delete(this.attachedMesh);
-        if (this.captureOnPointerEnter) {
+        if (this._captureOnPointerEnter) {
             stopCaptureOnEnter();
         }
         this.attachedMesh = null;


### PR DESCRIPTION
`this.captureOnPointerEnter` only has a setter method, and its value is always `undefined`, causing `stopCaptureOnEnter()` to fail to be called, and  the module level variable `_scene` can not changed to current scene when switch scenes.
fix issue https://github.com/BabylonJS/Extensions/issues/277