### PR TITLE
htmlmesh - relax babylonjs/core version dependency

### DIFF
--- a/HtmlMesh/package.json
+++ b/HtmlMesh/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/BabylonJS/Extensions"
   },
   "peerDependencies": {
-    "@babylonjs/core": "^6.30.0"
+    "@babylonjs/core": ">=6.30.0"
   },
   "devDependencies": {
     "@babylonjs/core": "^7.0.0",


### PR DESCRIPTION
Hi
the peerDependency of `@babylonjs/core` in HtmlMesh is currently bound to version 6.x, so when using it in project with Babylon v7, I'm getting this error:

```
$ npm update
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: babylonjs-typescript-webpack-template@0.0.1
npm error Found: @babylonjs/core@7.10.2
npm error node_modules/@babylonjs/core
npm error   @babylonjs/core@"^7.0.0" from the root project
npm error
npm error Could not resolve dependency:
npm error peer @babylonjs/core@"^6.30.0" from babylon-htmlmesh@1.2.0
npm error node_modules/babylon-htmlmesh
npm error   babylon-htmlmesh@"^1.2.0" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
```

I can override the issue as advised, but it seems there's no reason to keep the dependency pinned in as it is (?)
