### PR TITLE
Recastjs 1.6.4

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,14 +17,14 @@ steps:
       cd ..
       git clone https://github.com/emscripten-core/emsdk.git
       cd emsdk
-      ./emsdk install latest
+      ./emsdk install 3.1.51
   displayName: 'Clone/install emsdk'
 
 - task: CmdLine@2
   inputs:
     script: |
       pushd ../emsdk
-      ./emsdk activate latest
+      ./emsdk activate 3.1.51
       source "emsdk_env.sh"
       popd
       cd recastjs

--- a/recastjs/CMakeLists.txt
+++ b/recastjs/CMakeLists.txt
@@ -69,10 +69,10 @@ ADD_LIBRARY(${EXE_NAME} ${SRC_FILES} ${RECASTDETOUR_FILES})
 set(CMAKE_BUILD_TYPE Release CACHE STRING "Build Type")
 
 # Default is 64*1024*1024 = 64MB
-set(TOTAL_MEMORY 67108864 CACHE STRING "Total Memory")
+#set(TOTAL_MEMORY 67108864 CACHE STRING "Total Memory")
 
 # Enable for resizable heap, with some amount of slowness
-set(ALLOW_MEMORY_GROWTH 0 CACHE STRING "Allow Memory Growth")
+set(ALLOW_MEMORY_GROWTH 1 CACHE STRING "Allow Memory Growth")
 
 set(EMCC_ARGS
   -flto
@@ -88,7 +88,8 @@ set(EMCC_ARGS
   -s MODULARIZE=1
   -s NO_EXIT_RUNTIME=1
   -s NO_FILESYSTEM=1
-  -s TOTAL_MEMORY=${TOTAL_MEMORY})
+#  -s TOTAL_MEMORY=${TOTAL_MEMORY}
+)
 
 if(${CLOSURE})
   # Ignore closure errors about the bullet Node class

--- a/recastjs/package.json
+++ b/recastjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recast-detour",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "recastjs is a port of recastnavigation and a thin abstraction layer using emscripten. https://github.com/emscripten-core/emscripten\r This port allows the use of recastnavigation in your browser using JavaScript or WebAssembly.",
   "main": "recast.js",
   "module": "recast.es6.js",


### PR DESCRIPTION
- dynamic allocation
- emsdk version frozen with 3.1.51 as latest need deeper change in the build config

This package will hopefully be replaced by a new community project in the near future.
I'll kick the npm build/publish when this gets merged.