### PR TITLE
misc(htmlmesh): add babylon v8 as a supported dependency version

### DIFF
--- a/HtmlMesh/package-lock.json
+++ b/HtmlMesh/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.1",
       "license": "ISC",
       "devDependencies": {
-        "@babylonjs/core": "^7.0.0",
+        "@babylonjs/core": "^7.0.0 || ^8.0.0",
         "@types/jest": "^29.5.11",
         "jest": "^29.7.0",
         "ts-jest": "^29.1.1",
@@ -21,7 +21,7 @@
         "vite-plugin-externalize-deps": "^0.8.0"
       },
       "peerDependencies": {
-        "@babylonjs/core": "5.x || 6.x || 7.x"
+        "@babylonjs/core": "5.x || 6.x || 7.x || 8.x"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/HtmlMesh/package.json
+++ b/HtmlMesh/package.json
@@ -32,10 +32,10 @@
     "url": "https://github.com/BabylonJS/Extensions"
   },
   "peerDependencies": {
-    "@babylonjs/core": "5.x || 6.x || 7.x"
+    "@babylonjs/core": "5.x || 6.x || 7.x || 8.x"
   },
   "devDependencies": {
-    "@babylonjs/core": "^7.0.0",
+    "@babylonjs/core": "^7.0.0 || ^8.0.0",
     "@types/jest": "^29.5.11",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",


### PR DESCRIPTION
Add new major release as a supported dependency.

Also it looks like the htmlmesh version which lives in the main repo in [packages/dev/addons/src/htmlMesh](https://github.com/BabylonJS/Babylon.js/tree/master/packages/dev/addons/src/htmlMesh) is slightly out of sync with the version here.